### PR TITLE
Fix duplicate items bug

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -57,8 +57,8 @@ def scrape():
     """Runs one live scrape of all feeds."""
 
     for feed in Feed.query.all():
-        scrape_feed_articles(feed)
-        categorize_feed_articles(feed, categorizer)
+        scrape_feed_articles(feed.id)
+        categorize_feed_articles(feed.id, categorizer)
 
 
 @manager.command
@@ -154,8 +154,8 @@ def feed_seed():
                     db.session.commit()
 
         for feed in Feed.query.all():
-            scrape_feed_articles(feed)
-            categorize_feed_articles(feed, categorizer)
+            scrape_feed_articles(feed.id)
+            categorize_feed_articles(feed.id, categorizer)
 
 
 @manager.command
@@ -207,8 +207,8 @@ def seed():
         db.session.commit()
 
     # Scrape articles for feed
-    scrape_feed_articles(feed)
-    categorize_feed_articles(feed, categorizer)
+    scrape_feed_articles(feed.id)
+    categorize_feed_articles(feed.id, categorizer)
 
 manager.add_command('server', Server())
 manager.add_command('shell', Shell(make_context=_make_context))

--- a/manage.py
+++ b/manage.py
@@ -70,11 +70,11 @@ def scrape_loop():
 
         for feed in Feed.query.all():
             q.enqueue_call(func=scrape_feed_articles,
-                           args=(feed,), timeout=1800)
+                           args=(feed.id,), timeout=1800)
 
         for feed in Feed.query.all():
             q.enqueue_call(func=categorize_feed_articles,
-                           args=(feed, categorizer,), timeout=1800)
+                           args=(feed.id, categorizer,), timeout=1800)
 
         too_old = datetime.today() - timedelta(days=30)
 

--- a/sourcemash/api/feeds.py
+++ b/sourcemash/api/feeds.py
@@ -102,7 +102,7 @@ class FeedListAPI(Resource):
             # Scrape feed (but don't fail if redis-server is down)
             try:
                 q = Queue('scrape', connection=REDIS_CONNECTION)
-                job = q.enqueue_call(func=scrape_feed_articles, args=(feed,),
+                job = q.enqueue_call(func=scrape_feed_articles, args=(feed.id,),
                                      at_front=True, timeout=600)
             except:
                 pass

--- a/worker/scraper.py
+++ b/worker/scraper.py
@@ -18,7 +18,9 @@ logger = logging.getLogger('Sourcemash')
 SOURCEMASH_LOGO_URL = "http://sourcemash.com/static/img/solologo.svg"
 
 
-def scrape_feed_articles(feed):
+def scrape_feed_articles(feed_id):
+    feed = Feed.query.get(feed_id)
+
     _store_items(feed)
 
     for item in Item.query.filter_by(feed_id=feed.id).all():
@@ -40,8 +42,8 @@ def scrape_feed_articles(feed):
                 db.session.commit()
 
 
-def categorize_feed_articles(feed, categorizer):
-    for item in Item.query.filter_by(categorized=False).all():
+def categorize_feed_articles(feed_id, categorizer):
+    for item in Item.query.filter_by(categorized=False, feed_id=feed_id).all():
         soup = BeautifulSoup(item.text)
 
         # Extract text and categorize item


### PR DESCRIPTION
Objects committed to a queue keep their CURRENT STATE regardless of whether they are changed in the db, so you MUST query new instances of these objects from the database in queued tasks.
